### PR TITLE
Fix: Ensure AssistantMessage is saved in memory for streamed text-onl…

### DIFF
--- a/src/Agent/Tool/ToolUseAgent.php
+++ b/src/Agent/Tool/ToolUseAgent.php
@@ -194,12 +194,13 @@ class ToolUseAgent
                 continue;
             }
 
-            if (! empty($toolCalls)) {
+            if ($content !== '' || ! empty($toolCalls)) {
+                $finalContentForMessage = $content;
                 // 如果有 toolsCall 但是 content 是空，自动加上
-                if ($content === '') {
-                    $content = $this->assistantEmptyContentPlaceholder;
+                if ($content === '' && ! empty($toolCalls)) {
+                    $finalContentForMessage = $this->assistantEmptyContentPlaceholder;
                 }
-                $generatorSendMessage = new AssistantMessage($content, $toolCalls);
+                $generatorSendMessage = new AssistantMessage($finalContentForMessage, $toolCalls);
             }
 
             $gen->send($generatorSendMessage);


### PR DESCRIPTION
`chatStreamed()` 中构建 `$generatorSendMessage` 的条件判断似乎不严谨，我用 redis 驱动记忆，测试流式响应的时候发现如果让大模型不调用工具，只输出文本内容，会导致 `$generatorSendMessage` 为 `null`。
修改后的条件判断确保只要模型通过流式响应输出了任何文本内容（即使没有工具调用），`chatStreamed `都会构建`AssistantMessage` 并添加到记忆中。